### PR TITLE
Update install info in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ configurations.
 ## Installation
 
 ```
-git clone https://github.com/s1341/pyenv-alias.git $PYENV_ROOT/plugins/pyenv-alias
+git clone https://github.com/s1341/pyenv-alias.git $(pyenv root)/plugins/pyenv-alias
 ```
 
 ## Usage


### PR DESCRIPTION
Determine the installation prefix using the `pyenv` command instead of
using an environment variable (which may not be defined).
